### PR TITLE
feat: Add executable path for SCIP solver

### DIFF
--- a/module/src/TEO_Model.py
+++ b/module/src/TEO_Model.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import datetime as dt
 import logging
 import numpy as np
@@ -11,23 +12,22 @@ from .Visualization import *
 from .Visualization_short import *
 import gurobipy as gp
 
-def buildmodel(sets_df, df, defaults_df, mcs_df, n, names, solver):
 
+def buildmodel(sets_df, df, defaults_df, mcs_df, n, names, solver):
     modelName = "teo_model"
 
     # ----------------------------------------------------------------------------------------------------------------------
     #    SOLVER
     # ----------------------------------------------------------------------------------------------------------------------
-    path_to_scip = r'C:\Program Files\SCIPOptSuite 8.0.2\bin\scip.exe' #needs to be updated
-    
-    if solver=='SCIP':
-        modelsolver = pulp.SCIP_CMD(path=path_to_scip)
+    if solver == 'SCIP':
+        # executable = r'C:\Program Files\SCIPOptSuite 8.0.2\bin\scip.exe'
+        executable = f"{os.path.dirname(sys.executable)}/scip"
+        solver = pulp.SCIP_CMD(path=executable)
     else:
-        modelsolver = pulp.GUROBI()
+        solver = pulp.GUROBI()
     # ----------------------------------------------------------------------------------------------------------------------
     #    SETS (CHANGED FOR NEW FORMAT)
     # ----------------------------------------------------------------------------------------------------------------------
-    solver = pulp.GUROBI()
     YEAR = createTuple(sets_df["YEAR"], "YEAR")
     TECHNOLOGY = createTuple(sets_df["TECHNOLOGY"], "TECHNOLOGY")
     TIMESLICE = createTuple(sets_df["TIMESLICE"], "TIMESLICE")

--- a/module/src/integration.py
+++ b/module/src/integration.py
@@ -25,7 +25,7 @@ def _prepare_inputs(input_data):
     cf_module = input_data["cf-module"]
     platform = input_data["platform"]
     names = gis_module["names"]
-    solver = platform['solver']
+    solver = platform.get("solver")
 
     default_df = create_parameters_default_dataframe(kb["parameters_default"])
     jsset = platform["platform_sets"]


### PR DESCRIPTION
I just added a executable path for SCIP in UNIX servers, because our server is running on Linux. If you need to use it in Windows, you can set your windows path (just for local development).
I changed the mapping for solver using ".get" instead of access key directly to not broken simulations in QA environment, cause we use same branch of p-teo there.